### PR TITLE
[doc] Fix travis badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Graal: a Generic Repository AnALyzer [![Build Status](https://travis-ci.org/grimoirelab-graal.svg?branch=master)](https://travis-ci.org/chaoss/grimoirelab-graal) [![Coverage Status](https://coveralls.io/repos/github/chaoss/grimoirelab-graal/badge.svg?branch=master)](https://coveralls.io/github/chaoss/grimoirelab-graal?branch=master)
+# Graal: a Generic Repository AnALyzer [![Build Status](https://travis-ci.org/chaoss/grimoirelab-graal.svg?branch=master)](https://travis-ci.org/chaoss/grimoirelab-graal) [![Coverage Status](https://coveralls.io/repos/github/chaoss/grimoirelab-graal/badge.svg?branch=master)](https://coveralls.io/github/chaoss/grimoirelab-graal?branch=master)
 
 Graal leverages on the Git backend of [Perceval](https://github.com/chaoss/grimoirelab-perceval) and enhances it to set up ad-hoc
 source code analysis. Thus, it fetches the commits from a Git repository and provides a mechanism to plug third party tools/libraries focused on source code analysis.


### PR DESCRIPTION
This code fixes the url of the travis badge, which was missing the organization part.