### PR TITLE
[graal] Remove unused config_file option

### DIFF
--- a/bin/graal
+++ b/bin/graal
@@ -22,16 +22,14 @@
 #
 
 import argparse
-import configparser
 import logging
-import os.path
 import sys
 
 import graal.graal
 import graal.backends.core
 
 
-GRAAL_USAGE_MSG = """%(prog)s [-c <file>] [-g] <backend> [<args>] | --help | --version"""
+GRAAL_USAGE_MSG = """%(prog)s [-g] <backend> [<args>] | --help | --version"""
 
 GRAAL_DESC_MSG = """Start a Graal quest to retrieve source code data from Git repositories.
 
@@ -43,8 +41,6 @@ are:
 optional arguments:
   -h, --help            show this help message and exit
   -v, --version         show version
-  -c FILE, --config FILE
-                        set configuration file
   -g, --debug           set debug mode on
 """
 
@@ -60,12 +56,6 @@ GRAAL_DEBUG_LOG_FORMAT = "[%(asctime)s - %(name)s - %(levelname)s] - %(message)s
 
 def main():
     args = parse_args()
-
-    # Read default parameters from a configuration file
-    if args.config_file:
-        defaults = read_config_file(args.config_file, args.backend)
-    else:
-        defaults = {}
 
     _, GRAAL_CMDS = graal.graal.find_backends(graal.backends)
 
@@ -97,13 +87,9 @@ def parse_args():
     parser.add_argument('-v', '--version', action='version',
                         version=GRAAL_VERSION_MSG,
                         help=argparse.SUPPRESS)
-    parser.add_argument('-c', '--config', dest='config_file',
-                        default=os.path.expanduser('~/.graal/graal.cfg'),
-                        help=argparse.SUPPRESS)
     parser.add_argument('-g', '--debug', dest='debug',
                         action='store_true',
                         help=argparse.SUPPRESS)
-
     parser.add_argument('backend', help=argparse.SUPPRESS)
     parser.add_argument('backend_args', nargs=argparse.REMAINDER,
                         help=argparse.SUPPRESS)
@@ -113,31 +99,6 @@ def parse_args():
         sys.exit(1)
 
     return parser.parse_args()
-
-
-def read_config_file(filepath, backend):
-    """Read a Perceval configuration file.
-
-    This function reads common and `backend` configuration parameters
-    from the given file.
-
-    :param filepath: path to the configuration file
-    :param backend: name of the backend which its parameters will be read
-
-    :returns: a configuration parameters dictionary
-    """
-    config = configparser.SafeConfigParser()
-    config.read(filepath)
-
-    args = {}
-    sections = ['archive', backend]
-
-    for section in sections:
-        if section in config.sections():
-            d = dict(config.items(section))
-            args.update(d)
-
-    return args
 
 
 def configure_logging(debug=False):


### PR DESCRIPTION
~~I ran graal from the terminal and the following warning popped up:~~

<img width="1440" alt="Screenshot 2019-03-10 at 6 14 39 PM" src="https://user-images.githubusercontent.com/9946566/54085472-90677280-4364-11e9-810d-051077712c92.png">

~~This code is about fixing that warning by using `ConfigParser` class instead of `SafeConfigParser`.~~

EDIT: Removed the unused code to pass a config file through command line while running graal.