### PR TITLE
[graal] Fix `exec_path` param in `GraalCommandArgumentParser`.

### DIFF
--- a/graal/graal.py
+++ b/graal/graal.py
@@ -535,8 +535,7 @@ class GraalCommandArgumentParser:
 
         if exec_path:
             group.add_argument('--exec-path', dest='exec_path',
-                               default='1970-01-01',
-                               help="fetch items updated since this date")
+                               help="local path of the particular tool")
 
         self._set_output_arguments()
 


### PR DESCRIPTION
Remove the default value of the `exec_path` in the class `GraalCommandArgumentParser` and fix its help message.