### PR TITLE
Add flake8 analyzer to CoQua backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ and define the **details** level of the analysis (useful when analyzing large so
 - lizard>=1.16.3
 - perceval>=0.9.6
 - pylint>=1.8.4
+- flake8>=3.7.7
 - networkx>=2.1
 - pydot>=1.2.4
 - bandit>=1.4.0
@@ -78,7 +79,7 @@ programming languages such as: C/C++, Java, Scala, JavaScript, Ruby, Python, Lua
 edges and nodes, thus easing the bridging with front-end technologies for graph visualizations. It combines [PyReverse](https://pypi.org/project/pyreverse/)
 and [NetworkX](https://networkx.github.io/).
 - **CoQua** retrieves code quality insights, such as checks about line-code’s length, well-formed variable names, unused
-imported modules and code clones. It uses [PyLint](https://www.pylint.org/).
+imported modules and code clones. It uses [PyLint](https://www.pylint.org/) and [Flake8](http://flake8.pycqa.org/en/latest/index.html).
 - **CoVuln** scans the code to identify security vulnerabilities such as potential SQL and Shell injections, hard-coded
 passwords and weak cryptographic key size. It relies on [Bandit](https://github.com/PyCQA/bandit).
 - **CoLic** scans the code to extract license information. It currently supports [Nomos](https://github.com/fossology/fossology/tree/master/src/nomos) and [ScanCode](https://github.com/nexB/scancode-toolkit). They can be

--- a/graal/backends/core/analyzers/flake8.py
+++ b/graal/backends/core/analyzers/flake8.py
@@ -48,7 +48,7 @@ class Flake8(Analyzer):
         finally:
             subprocess._cleanup()
 
-        lines = msg.split('\n')
+        lines = msg.strip().split('\n') if msg else []
 
         result = {'warnings': len(lines)}
 

--- a/graal/backends/core/analyzers/flake8.py
+++ b/graal/backends/core/analyzers/flake8.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*- the Graal backend.
+#
+# Copyright (C) 2015-2019 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+#
+# Authors:
+#     Nishchith Shetty <inishchith@gmail.com>
+#
+
+import subprocess
+
+from graal.graal import GraalError
+from .analyzer import Analyzer
+
+
+class Flake8(Analyzer):
+    """A wrapper for Flake8, a source code style checker for Python."""
+
+    version = '0.2.0'
+
+    def analyze(self, **kwargs):
+        """Add quality checks data using Flake8.
+
+        :param module_path: module path
+        :param details: if True, it returns information about single commit
+
+        :returns result: dict of the results of the analysis
+        """
+        module_path = kwargs['module_path']
+        details = kwargs['details']
+
+        try:
+            msg = subprocess.check_output(['flake8', module_path]).decode("utf-8")
+        except subprocess.CalledProcessError as e:
+            msg = e.output.decode("utf-8")
+        finally:
+            subprocess._cleanup()
+
+        lines = msg.split('\n')
+
+        result = {'warnings': len(lines)}
+
+        if details:
+            result['lines'] = lines
+
+        return result

--- a/graal/backends/core/analyzers/flake8.py
+++ b/graal/backends/core/analyzers/flake8.py
@@ -28,7 +28,7 @@ from .analyzer import Analyzer
 class Flake8(Analyzer):
     """A wrapper for Flake8, a source code style checker for Python."""
 
-    version = '0.2.0'
+    version = '0.1.0'
 
     def analyze(self, **kwargs):
         """Add quality checks data using Flake8.

--- a/graal/backends/core/analyzers/flake8.py
+++ b/graal/backends/core/analyzers/flake8.py
@@ -22,7 +22,6 @@
 
 import subprocess
 
-from graal.graal import GraalError
 from .analyzer import Analyzer
 
 

--- a/graal/backends/core/analyzers/pylint.py
+++ b/graal/backends/core/analyzers/pylint.py
@@ -26,7 +26,7 @@ from graal.graal import GraalError
 from .analyzer import Analyzer
 
 
-class Lint(Analyzer):
+class PyLint(Analyzer):
     """A wrapper for Pylint, a source code, bug and quality checker for Python."""
 
     version = '0.2.0'

--- a/graal/backends/core/analyzers/pylint.py
+++ b/graal/backends/core/analyzers/pylint.py
@@ -29,7 +29,7 @@ from .analyzer import Analyzer
 class PyLint(Analyzer):
     """A wrapper for Pylint, a source code, bug and quality checker for Python."""
 
-    version = '0.2.0'
+    version = '0.2.1'
 
     def analyze(self, **kwargs):
         """Add quality checks data using Pylint.

--- a/graal/backends/core/coqua.py
+++ b/graal/backends/core/coqua.py
@@ -133,7 +133,7 @@ class CoQua(Graal):
                            % (module_path, commit['commit']))
             return {}
 
-        analysis = self.module_analyzer.analyze(module_path)
+        analysis = self.module_analyzer.analyze(module_path, self.worktreepath)
 
         return analysis
 
@@ -160,15 +160,18 @@ class ModuleAnalyzer:
 
     def __init__(self, details=False, kind=PYLINT):
         self.details = details
+        self.kind = kind
+
         if kind == PYLINT:
             self.analyzer = PyLint()
         else:
             self.analyzer = Flake8()
 
-    def analyze(self, module_path):
+    def analyze(self, module_path, worktree_path):
         """Analyze the content of a module
 
         :param module_path: module path
+        :param worktree_path: worktree path
 
         :returns a dict containing the results of the analysis, like the one below
         {
@@ -179,6 +182,8 @@ class ModuleAnalyzer:
             'module_path': module_path,
             'details': self.details
         }
+        if self.kind == FLAKE8:
+            kwargs['worktree_path'] = worktree_path
         analysis = self.analyzer.analyze(**kwargs)
 
         return analysis

--- a/graal/backends/core/coqua.py
+++ b/graal/backends/core/coqua.py
@@ -153,7 +153,7 @@ class CoQua(Graal):
 
 class ModuleAnalyzer:
     """Class to evaluate code quality in a Python project
-    
+
     :params details: if enable, it returns fine-grained results
     :param kind: the analyzer kind (e.g., PYLINT, FLAKE8)
     """

--- a/graal/backends/core/coqua.py
+++ b/graal/backends/core/coqua.py
@@ -60,7 +60,7 @@ class CoQua(Graal):
     :raises RepositoryError: raised when there was an error cloning or
         updating the repository.
     """
-    version = '0.2.1'
+    version = '0.3.0'
 
     CATEGORIES = [CATEGORY_COQUA_PYLINT, CATEGORY_COQUA_FLAKE8]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 lizard>=1.16.3
 pylint>=1.8.4
+flake8>=3.7.7
 networkx>=2.1
 pydot>=1.2.4
 bandit>=1.4.0

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ setup(name="graal",
           'lizard>=1.16.3',
           'perceval>=0.12.0',
           'pylint>=1.8.4',
+          'flake8>=3.7.7',
           'networkx>=2.1',
           'pydot>=1.2.4',
           'bandit>=1.4.0'

--- a/tests/test_coqua.py
+++ b/tests/test_coqua.py
@@ -194,7 +194,7 @@ class TestModuleAnalyzer(TestCaseAnalyzer):
 
         repo_name = 'graaltest'
         cls.repo_path = os.path.join(cls.tmp_path, repo_name)
-        cls.worktree_path = os.path.join(cls.tmp_path, 'colic_worktrees')
+        cls.worktree_path = os.path.join(cls.tmp_path, 'coqua_worktrees')
 
         fdout, _ = tempfile.mkstemp(dir=cls.tmp_path)
 

--- a/tests/test_flake8.py
+++ b/tests/test_flake8.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+#
+# Authors:
+#     Nishchith Shetty <inishchith@gmail.com>
+#
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+import unittest.mock
+
+from base_analyzer import (TestCaseAnalyzer,
+                           ANALYZER_TEST_FILE)
+
+from graal.backends.core.analyzers.flake8 import Flake8
+
+
+class TestFlake8(TestCaseAnalyzer):
+    """Lint tests"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp_path = tempfile.mkdtemp(prefix='graal_')
+
+        data_path = os.path.dirname(os.path.abspath(__file__))
+        data_path = os.path.join(data_path, 'data')
+
+        repo_name = 'graaltest'
+        cls.repo_path = os.path.join(cls.tmp_path, repo_name)
+
+        fdout, _ = tempfile.mkstemp(dir=cls.tmp_path)
+
+        zip_path = os.path.join(data_path, repo_name + '.zip')
+        subprocess.check_call(['unzip', '-qq', zip_path, '-d', cls.tmp_path])
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmp_path)
+
+    def test_analyze_details(self):
+        """Test whether lint returns the expected fields data"""
+
+        lint = Flake8()
+        kwargs = {
+            'module_path': os.path.join(self.repo_path, "perceval"),
+            'details': True
+        }
+        result = lint.analyze(**kwargs)
+
+        self.assertIn('lines', result)
+        self.assertTrue(type(result['lines']), list)
+        self.assertIn('warnings', result)
+        self.assertTrue(type(result['warnings']), int)
+
+    def test_analyze_no_details(self):
+        """Test whether lint returns the expected fields data"""
+
+        lint = Flake8()
+        kwargs = {
+            'module_path': os.path.join(self.repo_path, ANALYZER_TEST_FILE),
+            'details': False
+        }
+        result = lint.analyze(**kwargs)
+
+        self.assertNotIn('lines', result)
+        self.assertIn('warnings', result)
+        self.assertTrue(type(result['warnings']), int)
+
+    @unittest.mock.patch('subprocess.check_output')
+    def test_analyze_error(self, check_output_mock):
+        """Test whether an exception is thrown in case of errors"""
+
+        check_output_mock.side_effect = subprocess.CalledProcessError(
+            -1, "command", output=b'output')
+
+        lint = Flake8()
+        kwargs = {
+            'module_path': os.path.join(self.repo_path, ANALYZER_TEST_FILE),
+            'details': False
+        }
+        _ = lint.analyze(**kwargs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_flake8.py
+++ b/tests/test_flake8.py
@@ -46,6 +46,7 @@ class TestFlake8(TestCaseAnalyzer):
 
         repo_name = 'graaltest'
         cls.repo_path = os.path.join(cls.tmp_path, repo_name)
+        cls.worktree_path = os.path.join(cls.tmp_path, 'coqua_worktrees')
 
         fdout, _ = tempfile.mkstemp(dir=cls.tmp_path)
 
@@ -62,6 +63,7 @@ class TestFlake8(TestCaseAnalyzer):
         flake8 = Flake8()
         kwargs = {
             'module_path': os.path.join(self.repo_path, "perceval"),
+            'worktree_path': self.worktree_path,
             'details': True
         }
         result = flake8.analyze(**kwargs)
@@ -77,6 +79,7 @@ class TestFlake8(TestCaseAnalyzer):
         flake8 = Flake8()
         kwargs = {
             'module_path': os.path.join(self.repo_path, ANALYZER_TEST_FILE),
+            'worktree_path': self.worktree_path,
             'details': False
         }
         result = flake8.analyze(**kwargs)
@@ -95,6 +98,7 @@ class TestFlake8(TestCaseAnalyzer):
         flake8 = Flake8()
         kwargs = {
             'module_path': os.path.join(self.repo_path, ANALYZER_TEST_FILE),
+            'worktree_path': self.worktree_path,
             'details': False
         }
         _ = flake8.analyze(**kwargs)

--- a/tests/test_flake8.py
+++ b/tests/test_flake8.py
@@ -35,7 +35,7 @@ from graal.backends.core.analyzers.flake8 import Flake8
 
 
 class TestFlake8(TestCaseAnalyzer):
-    """Lint tests"""
+    """Flake8 tests"""
 
     @classmethod
     def setUpClass(cls):
@@ -57,14 +57,14 @@ class TestFlake8(TestCaseAnalyzer):
         shutil.rmtree(cls.tmp_path)
 
     def test_analyze_details(self):
-        """Test whether lint returns the expected fields data"""
+        """Test whether flake8 returns the expected fields data"""
 
-        lint = Flake8()
+        flake8 = Flake8()
         kwargs = {
             'module_path': os.path.join(self.repo_path, "perceval"),
             'details': True
         }
-        result = lint.analyze(**kwargs)
+        result = flake8.analyze(**kwargs)
 
         self.assertIn('lines', result)
         self.assertTrue(type(result['lines']), list)
@@ -72,14 +72,14 @@ class TestFlake8(TestCaseAnalyzer):
         self.assertTrue(type(result['warnings']), int)
 
     def test_analyze_no_details(self):
-        """Test whether lint returns the expected fields data"""
+        """Test whether flake8 returns the expected fields data"""
 
-        lint = Flake8()
+        flake8 = Flake8()
         kwargs = {
             'module_path': os.path.join(self.repo_path, ANALYZER_TEST_FILE),
             'details': False
         }
-        result = lint.analyze(**kwargs)
+        result = flake8.analyze(**kwargs)
 
         self.assertNotIn('lines', result)
         self.assertIn('warnings', result)
@@ -92,12 +92,12 @@ class TestFlake8(TestCaseAnalyzer):
         check_output_mock.side_effect = subprocess.CalledProcessError(
             -1, "command", output=b'output')
 
-        lint = Flake8()
+        flake8 = Flake8()
         kwargs = {
             'module_path': os.path.join(self.repo_path, ANALYZER_TEST_FILE),
             'details': False
         }
-        _ = lint.analyze(**kwargs)
+        _ = flake8.analyze(**kwargs)
 
 
 if __name__ == "__main__":

--- a/tests/test_pylint.py
+++ b/tests/test_pylint.py
@@ -36,7 +36,7 @@ from graal.graal import GraalError
 
 
 class TestPyLint(TestCaseAnalyzer):
-    """Lint tests"""
+    """PyLint tests"""
 
     @classmethod
     def setUpClass(cls):
@@ -58,14 +58,14 @@ class TestPyLint(TestCaseAnalyzer):
         shutil.rmtree(cls.tmp_path)
 
     def test_analyze_details(self):
-        """Test whether lint returns the expected fields data"""
+        """Test whether pylint returns the expected fields data"""
 
-        lint = PyLint()
+        pylint = PyLint()
         kwargs = {
             'module_path': os.path.join(self.repo_path, "perceval"),
             'details': True
         }
-        result = lint.analyze(**kwargs)
+        result = pylint.analyze(**kwargs)
 
         self.assertIn('quality', result)
         self.assertTrue(type(result['quality']), str)
@@ -81,14 +81,14 @@ class TestPyLint(TestCaseAnalyzer):
             self.assertTrue(type(md), str)
 
     def test_analyze_no_details(self):
-        """Test whether lint returns the expected fields data"""
+        """Test whether pylint returns the expected fields data"""
 
-        lint = PyLint()
+        pylint = PyLint()
         kwargs = {
             'module_path': os.path.join(self.repo_path, ANALYZER_TEST_FILE),
             'details': False
         }
-        result = lint.analyze(**kwargs)
+        result = pylint.analyze(**kwargs)
 
         self.assertNotIn('modules', result)
         self.assertIn('quality', result)
@@ -104,13 +104,13 @@ class TestPyLint(TestCaseAnalyzer):
 
         check_output_mock.side_effect = subprocess.CalledProcessError(-1, "command", output=b'output')
 
-        lint = PyLint()
+        pylint = PyLint()
         kwargs = {
             'module_path': os.path.join(self.repo_path, ANALYZER_TEST_FILE),
             'details': False
         }
         with self.assertRaises(GraalError):
-            _ = lint.analyze(**kwargs)
+            _ = pylint.analyze(**kwargs)
 
 
 if __name__ == "__main__":

--- a/tests/test_pylint.py
+++ b/tests/test_pylint.py
@@ -31,11 +31,11 @@ import unittest.mock
 from base_analyzer import (TestCaseAnalyzer,
                            ANALYZER_TEST_FILE)
 
-from graal.backends.core.analyzers.lint import Lint
+from graal.backends.core.analyzers.pylint import PyLint
 from graal.graal import GraalError
 
 
-class TestLint(TestCaseAnalyzer):
+class TestPyLint(TestCaseAnalyzer):
     """Lint tests"""
 
     @classmethod
@@ -60,7 +60,7 @@ class TestLint(TestCaseAnalyzer):
     def test_analyze_details(self):
         """Test whether lint returns the expected fields data"""
 
-        lint = Lint()
+        lint = PyLint()
         kwargs = {
             'module_path': os.path.join(self.repo_path, "perceval"),
             'details': True
@@ -83,7 +83,7 @@ class TestLint(TestCaseAnalyzer):
     def test_analyze_no_details(self):
         """Test whether lint returns the expected fields data"""
 
-        lint = Lint()
+        lint = PyLint()
         kwargs = {
             'module_path': os.path.join(self.repo_path, ANALYZER_TEST_FILE),
             'details': False
@@ -104,7 +104,7 @@ class TestLint(TestCaseAnalyzer):
 
         check_output_mock.side_effect = subprocess.CalledProcessError(-1, "command", output=b'output')
 
-        lint = Lint()
+        lint = PyLint()
         kwargs = {
             'module_path': os.path.join(self.repo_path, ANALYZER_TEST_FILE),
             'details': False


### PR DESCRIPTION
 - **Source**
   - Added flake8 analyzer for CoQua backend 
   - Updated CoQua backend in order to add parameter to select either `pylint` or `flake8`. Defualt set to `pylint`.
- **Tests**
  - Updated CoQua backend tests 
  - Added tests for Flake8 analyzer 

@valeriocos Please review and let me know if any changes required :)