### PR TITLE
[tests] Fix failing tests due to NOMOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ before_script:
   - cd exec
   - git clone https://github.com/fossology/fossology
   - cd fossology/src/nomos/agent/
-  - make -f Makefile.sa
+  - sudo apt-get install libjson-c-dev
+  - make -f Makefile.sa FO_LDFLAGS="-lglib-2.0 -lpq -lglib-2.0 -ljson-c -lpthread -lrt"
   - cd /home/travis/build/chaoss/grimoirelab-graal/exec
   - wget https://github.com/nexB/scancode-toolkit/releases/download/v3.0.0/scancode-toolkit-3.0.0.zip
   - unzip -q scancode-toolkit-3.0.0.zip


### PR DESCRIPTION
About weeks back, [this](https://github.com/fossology/fossology/commit/229860e6f8ffad522abec29ac381d6a5968ca6d0) change would cause errors due to a header file not found during build of NOMOS executables and hence the leading to failing tests. 

1. This PR checks out to a previous stable snapshot of the commit on Fossology and hence fixing the issue.
2. This also adds @jgbarah 's [this](https://github.com/chaoss/grimoirelab-graal/pull/17) PRs requested changes on build to `.travis.yml`.

@valeriocos Let me know what you think for this solution 😅 
Thanks

Signed-off-by: inishchith <inishchith@gmail.com>