### PR TITLE
[cocom] Add repository level analysis via lizard

### DIFF
--- a/tests/test_lizard.py
+++ b/tests/test_lizard.py
@@ -33,8 +33,8 @@ from graal.backends.core.analyzers.lizard import Lizard
 class TestLizard(TestCaseAnalyzer):
     """Lizard tests"""
 
-    def test_analyze_no_details(self):
-        """Test whether lizard returns the expected fields data"""
+    def test_analyze_file_no_details(self):
+        """Test whether lizard returns the expected fields data for files"""
 
         lizard = Lizard()
         kwargs = {'file_path': os.path.join(self.tmp_data_path, ANALYZER_TEST_FILE),
@@ -57,8 +57,8 @@ class TestLizard(TestCaseAnalyzer):
         self.assertIn('tokens', result)
         self.assertTrue(type(result['tokens']), int)
 
-    def test_analyze_details(self):
-        """Test whether lizard returns the expected fields data"""
+    def test_analyze_file_details(self):
+        """Test whether lizard returns the expected fields data for files"""
 
         lizard = Lizard()
         kwargs = {'file_path': os.path.join(self.tmp_data_path, ANALYZER_TEST_FILE),
@@ -99,6 +99,32 @@ class TestLizard(TestCaseAnalyzer):
             self.assertTrue(type(fd['start']), int)
             self.assertIn('end', fd)
             self.assertTrue(type(fd['end']), int)
+
+    def test_analyze_repository(self):
+        """Test whether lizard returns the expected fields data for repository"""
+
+        lizard = Lizard()
+        kwargs = {'repository_path': self.tmp_data_path,
+                  'repository_level': True,
+                  'files_affected': [],
+                  'details': False}
+        result = lizard.analyze(**kwargs)
+        result = result[0]
+
+        self.assertIn('ccn', result)
+        self.assertTrue(type(result['ccn']), int)
+        self.assertIn('num_funs', result)
+        self.assertTrue(type(result['num_funs']), int)
+        self.assertIn('loc', result)
+        self.assertTrue(type(result['loc']), int)
+        self.assertIn('tokens', result)
+        self.assertTrue(type(result['tokens']), int)
+        self.assertIn('in_commit', result)
+        self.assertTrue(type(result['in_commit']), bool)
+        self.assertIn('blanks', result)
+        self.assertTrue(type(result['blanks']), int)
+        self.assertIn('comments', result)
+        self.assertTrue(type(result['comments']), int)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A repository level analysis implementation for CoCom Backend via Lizard. 
This implementation doesn't harm the `incremental fetches` (which was one of the issues with implementation proposed in  #38)

**Evaluation:**

| Repository   | Number of Commits |  *File Level           | Repository Level  |
| :-------------: | :---------: |:-------------: | :-----:|
| [chaoss/grimoirelab-perceval]()| 1387 | 23.65 min |  27.97 min |
| [chaoss/grimoirelab-sirmordred]() | 869 | 9.69 min | 4.27 min |
| [chaoss/grimoirelab-graal]()   | 169 |  1.73 min  | 0.90 min |


@valeriocos Please do have a look when you get time. Thanks :)

**WIP**
- [x] Tests
- [x] Docstrings

Closes #36 

Signed-off-by: inishchith <inishchith@gmail.com>