### PR TITLE
[analyzer] Fix scancode_cli results

### DIFF
--- a/graal/backends/core/analyzers/scancode.py
+++ b/graal/backends/core/analyzers/scancode.py
@@ -76,9 +76,9 @@ class ScanCode(Analyzer):
         """Add information about license using scancode-cli
 
         :param file_paths: file paths (in case of scancode_cli for concurrent execution on files)
-        :returns result: dict of the results of the analysis
+        :returns result: list of the results of the analysis
         """
-        result = {'files': []}
+        result = []
 
         try:
             cmd_scancli = ['python3', self.exec_path]
@@ -107,7 +107,7 @@ class ScanCode(Analyzer):
 
         for output_json in outputs_json:
             file_info = output_json[0]['files'][0]
-            result['files'].append(file_info)
+            result.append(file_info)
 
         return result
 
@@ -117,7 +117,7 @@ class ScanCode(Analyzer):
         :param file_path: file path (in case of scancode)
         :param file_paths: file paths ( in case of scancode_cli for concurrent execution on files )
 
-        :returns result: dict of the results of the analysis
+        :returns result: the results of the analysis
         """
         if self.cli:
             result = self.__analyze_scancode_cli(kwargs['file_paths'])

--- a/graal/backends/core/colic.py
+++ b/graal/backends/core/colic.py
@@ -169,8 +169,8 @@ class CoLic(Graal):
         if files_to_process:
             local_paths = [path[1] for path in files_to_process]
             analysis = self.analyzer.analyze(local_paths)
-            for i in range(len(analysis['files'])):
-                analysis['files'][i]['file_path'] = files_to_process[i][0]
+            for i in range(len(analysis)):
+                analysis[i]['file_path'] = files_to_process[i][0]
 
         return analysis
 

--- a/tests/test_colic.py
+++ b/tests/test_colic.py
@@ -174,7 +174,7 @@ class TestCoLicBackend(TestCaseGraal):
         for commit in commits:
             self.assertEqual(commit['backend_name'], 'CoLic')
             self.assertEqual(commit['category'], CATEGORY_COLIC_SCANCODE_CLI)
-            self.assertEqual(commit['data']['analysis']['files'][0]['file_path'],
+            self.assertEqual(commit['data']['analysis'][0]['file_path'],
                              'perceval/backends/core/github.py')
             self.assertTrue('Author' in commit['data'])
             self.assertTrue('Commit' in commit['data'])
@@ -288,7 +288,7 @@ class TestLicenseAnalyzer(TestCaseAnalyzer):
         license_analyzer = LicenseAnalyzer(SCANCODE_CLI_PATH, kind=SCANCODE_CLI)
         analysis = license_analyzer.analyze(file_paths)
 
-        self.assertIn('licenses', analysis['files'][0])
+        self.assertIn('licenses', analysis[0])
 
 
 class TestCoLicCommand(unittest.TestCase):

--- a/tests/test_scancode.py
+++ b/tests/test_scancode.py
@@ -86,7 +86,7 @@ class TestScanCodeCli(TestCaseAnalyzer):
         kwargs = {'file_paths': [os.path.join(self.tmp_data_path, ANALYZER_TEST_FILE)]}
         result = scancode_cli.analyze(**kwargs)
 
-        self.assertIn('licenses', result['files'][0])
+        self.assertIn('licenses', result[0])
 
     def test_analyze_error(self):
         """Test whether an exception is thrown in case of error"""


### PR DESCRIPTION

> I had noticed that the structure of analysis(for code_license_scancode_cli ) is different(dict) as compared to other categories (list). Sorry for the mistake. 

@valeriocos Please do have a look :)

Signed-off-by: inishchith <inishchith@gmail.com>