### PR TITLE
[tests] Fix test_init in test_graal

### DIFF
--- a/tests/test_graal.py
+++ b/tests/test_graal.py
@@ -344,7 +344,10 @@ class TestGraalRepository(TestCaseGraal):
         expected = {
             'LANG': 'C',
             'PAGER': '',
-            'HOME': ''
+            'HOME': '',
+            'HTTPS_PROXY': '',
+            'HTTP_PROXY': '',
+            'NO_PROXY': ''
         }
         self.assertDictEqual(repo.gitenv, expected)
 


### PR DESCRIPTION
This code aligns the test_init to the recent changes in the Git Perceval backend: perceval/b311541