### PR TITLE
[cloc] Fix cloc error due to mulitple word language-name

### DIFF
--- a/graal/backends/core/analyzers/cloc.py
+++ b/graal/backends/core/analyzers/cloc.py
@@ -32,7 +32,7 @@ class Cloc(Analyzer):
     This class allows to call Cloc over a file, parses
     the result of the analysis and returns it as a dict.
     """
-    version = '0.2.0'
+    version = '0.2.1'
 
     def __analyze_file(self, message):
         """Add information about LOC, blank and commented lines using CLOC for a given file
@@ -52,11 +52,8 @@ class Cloc(Analyzer):
         for line in message.strip().split("\n"):
             if flag:
                 if not line.startswith("-----"):
-                    digested = " ".join(line.split())
-                    info_file = digested.split(" ")
-                    blank_lines = int(info_file[2])
-                    commented_lines = int(info_file[3])
-                    loc = int(info_file[4])
+                    file_info = line.split()[-3:]
+                    blank_lines, commented_lines, loc = map(int, file_info)
                     results["blanks"] = blank_lines
                     results["comments"] = commented_lines
                     results["loc"] = loc
@@ -83,14 +80,12 @@ class Cloc(Analyzer):
                 if line.lower().startswith("sum"):
                     break
                 elif not line.startswith("-----"):
-                    digested = " ".join(line.split())
-                    info_file = digested.split(" ")
-                    blank_lines = int(info_file[2])
-                    commented_lines = int(info_file[3])
-                    loc = int(info_file[4])
-                    language = info_file[0]
+                    digested_split = line.split()
+                    langauge, files_info = digested_split[:-4], digested_split[-4:]
+                    language = " ".join(langauge)
+                    total_files, blank_lines, commented_lines, loc = map(int, files_info)
                     language_result = {
-                        "total_files": int(info_file[1]),
+                        "total_files": total_files,
                         "blanks": blank_lines,
                         "comments": commented_lines,
                         "loc": loc

--- a/tests/test_cloc.py
+++ b/tests/test_cloc.py
@@ -67,10 +67,13 @@ class TestCloc(TestCaseAnalyzer):
 
         self.assertIn('blanks', result)
         self.assertTrue(type(result['blanks']), int)
+        self.assertTrue(result['blanks'], 27)
         self.assertIn('comments', result)
         self.assertTrue(type(result['comments']), int)
+        self.assertTrue(result['comments'], 31)
         self.assertIn('loc', result)
         self.assertTrue(type(result['loc']), int)
+        self.assertTrue(result['loc'], 67)
 
     def test_analyze_repository_level(self):
         """Test whether cloc returns the expected fields data for repository level"""


### PR DESCRIPTION
@valeriocos As I was working on large repository evaluation(https://github.com/inishchith/gsoc-graal/issues/12#issuecomment-513395968), enter this error in logic under `cloc` analyzer which depends on reporting of results based on position in the list.

- For instance, in the following example 3rd element:
   1. represents number of blank lines (int)
   2. here it's part of language name (str)
```
i. ['YAML', '1', '3', '0', '16']
ii. ['Bourne', 'Again', 'Shell', '1', '13', '18', '105']   <--------- Error
```

This PR fixes the error by picking the elements from the last(right to left). Please let me know what you think :)

Signed-off-by: inishchith <inishchith@gmail.com>