### PR TITLE
[analyzer] Add `diff_timeout` param to cloc analyzer

### DIFF
--- a/graal/backends/core/analyzers/cloc.py
+++ b/graal/backends/core/analyzers/cloc.py
@@ -25,14 +25,21 @@ from graal.graal import (GraalError,
                          GraalRepository)
 from .analyzer import Analyzer
 
+DEFAULT_DIFF_TIMEOUT = 60
+
 
 class Cloc(Analyzer):
     """A wrapper for Cloc.
 
     This class allows to call Cloc over a file, parses
     the result of the analysis and returns it as a dict.
+
+    :param diff_timeout: max time to compute diffs of a given file
     """
-    version = '0.2.1'
+    version = '0.3.0'
+
+    def __init__(self, diff_timeout=DEFAULT_DIFF_TIMEOUT):
+        self.diff_timeout = diff_timeout
 
     def __analyze_file(self, message):
         """Add information about LOC, blank and commented lines using CLOC for a given file
@@ -110,7 +117,8 @@ class Cloc(Analyzer):
         repository_level = kwargs.get('repository_level', False)
 
         try:
-            message = subprocess.check_output(['cloc', file_path]).decode("utf-8")
+            cloc_command = ['cloc', file_path, '--diff-timeout', str(self.diff_timeout)]
+            message = subprocess.check_output(cloc_command).decode("utf-8")
         except subprocess.CalledProcessError as e:
             raise GraalError(cause="Cloc failed at %s, %s" % (file_path, e.output.decode("utf-8")))
         finally:

--- a/tests/test_cloc.py
+++ b/tests/test_cloc.py
@@ -30,7 +30,8 @@ import unittest.mock
 from base_analyzer import (TestCaseAnalyzer,
                            ANALYZER_TEST_FILE)
 
-from graal.backends.core.analyzers.cloc import Cloc
+from graal.backends.core.analyzers.cloc import (Cloc,
+                                                DEFAULT_DIFF_TIMEOUT)
 from graal.graal import GraalError
 
 
@@ -57,6 +58,15 @@ class TestCloc(TestCaseAnalyzer):
     @classmethod
     def tearDownClass(cls):
         shutil.rmtree(cls.tmp_path)
+
+    def test_initialization(self):
+        """Test whether attributes are initializated"""
+
+        c = Cloc()
+        self.assertEqual(c.diff_timeout, DEFAULT_DIFF_TIMEOUT)
+
+        c = Cloc(diff_timeout=50)
+        self.assertEqual(c.diff_timeout, 50)
 
     def test_analyze(self):
         """Test whether cloc returns the expected fields data"""


### PR DESCRIPTION
This code increases the `diff_timeout` value to cope with diff calculation for large files (mostly
javascript ones). Cloc analyzer version and tests have been updated accordingly.