### PR TITLE
[colic] Filter dir paths and softlinks from analysis

### DIFF
--- a/graal/backends/core/colic.py
+++ b/graal/backends/core/colic.py
@@ -61,7 +61,7 @@ class CoLic(Graal):
     :raises RepositoryError: raised when there was an error cloning or
         updating the repository.
     """
-    version = '0.5.1'
+    version = '0.5.2'
 
     CATEGORIES = [CATEGORY_COLIC_NOMOS,
                   CATEGORY_COLIC_SCANCODE,
@@ -156,7 +156,8 @@ class CoLic(Graal):
                 if not found:
                     continue
 
-            if not GraalRepository.exists(local_path) or os.path.isdir(local_path):
+            # Skip files that don't exist, directories and soft links
+            if not GraalRepository.exists(local_path) or os.path.isdir(local_path) or os.path.islink(local_path):
                 continue
 
             if self.analyzer_kind == NOMOS or self.analyzer_kind == SCANCODE:

--- a/graal/backends/core/colic.py
+++ b/graal/backends/core/colic.py
@@ -20,6 +20,7 @@
 #
 
 import logging
+import os
 
 from graal.graal import (Graal,
                          GraalError,
@@ -60,7 +61,7 @@ class CoLic(Graal):
     :raises RepositoryError: raised when there was an error cloning or
         updating the repository.
     """
-    version = '0.5.0'
+    version = '0.5.1'
 
     CATEGORIES = [CATEGORY_COLIC_NOMOS,
                   CATEGORY_COLIC_SCANCODE,
@@ -147,15 +148,15 @@ class CoLic(Graal):
         files_to_process = []
 
         for committed_file in commit['files']:
-
             file_path = committed_file['file']
+            local_path = self.worktreepath + '/' + file_path
+
             if self.in_paths:
                 found = [p for p in self.in_paths if file_path.endswith(p)]
                 if not found:
                     continue
 
-            local_path = self.worktreepath + '/' + file_path
-            if not GraalRepository.exists(local_path):
+            if not GraalRepository.exists(local_path) or os.path.isdir(local_path):
                 continue
 
             if self.analyzer_kind == NOMOS or self.analyzer_kind == SCANCODE:


### PR DESCRIPTION
This PR filters directory paths and softlinks from the colic analysis. This change is needed to prevent failures in scancode-cli (issue #55).

Backend version is now set to 0.5.2