### PR TITLE
[backend] Change signature BackendCommandArgumentParser

### DIFF
--- a/graal/backends/core/cocom.py
+++ b/graal/backends/core/cocom.py
@@ -300,6 +300,6 @@ class CoComCommand(GraalCommand):
     def setup_cmd_parser(cls):
         """Returns the CoCom argument parser."""
 
-        parser = GraalCommand.setup_cmd_parser(cls.BACKEND.CATEGORIES)
+        parser = GraalCommand.setup_cmd_parser(cls.BACKEND)
 
         return parser

--- a/graal/backends/core/codep.py
+++ b/graal/backends/core/codep.py
@@ -162,6 +162,6 @@ class CoDepCommand(GraalCommand):
     def setup_cmd_parser(cls):
         """Returns the CoDep argument parser."""
 
-        parser = GraalCommand.setup_cmd_parser(cls.BACKEND.CATEGORIES)
+        parser = GraalCommand.setup_cmd_parser(cls.BACKEND)
 
         return parser

--- a/graal/backends/core/colang.py
+++ b/graal/backends/core/colang.py
@@ -184,6 +184,6 @@ class CoLangCommand(GraalCommand):
     def setup_cmd_parser(cls):
         """Returns the CoLang argument parser."""
 
-        parser = GraalCommand.setup_cmd_parser(cls.BACKEND.CATEGORIES)
+        parser = GraalCommand.setup_cmd_parser(cls.BACKEND)
 
         return parser

--- a/graal/backends/core/colic.py
+++ b/graal/backends/core/colic.py
@@ -234,6 +234,6 @@ class CoLicCommand(GraalCommand):
     def setup_cmd_parser(cls):
         """Returns the CoLic argument parser."""
 
-        parser = GraalCommand.setup_cmd_parser(cls.BACKEND.CATEGORIES, exec_path=True)
+        parser = GraalCommand.setup_cmd_parser(cls.BACKEND, exec_path=True)
 
         return parser

--- a/graal/backends/core/coqua.py
+++ b/graal/backends/core/coqua.py
@@ -197,6 +197,6 @@ class CoQuaCommand(GraalCommand):
     def setup_cmd_parser(cls):
         """Returns the CoQua argument parser."""
 
-        parser = GraalCommand.setup_cmd_parser(cls.BACKEND.CATEGORIES)
+        parser = GraalCommand.setup_cmd_parser(cls.BACKEND)
 
         return parser

--- a/graal/backends/core/covuln.py
+++ b/graal/backends/core/covuln.py
@@ -167,6 +167,6 @@ class CoVulnCommand(GraalCommand):
     def setup_cmd_parser(cls):
         """Returns the CoVuln argument parser."""
 
-        parser = GraalCommand.setup_cmd_parser(cls.BACKEND.CATEGORIES)
+        parser = GraalCommand.setup_cmd_parser(cls.BACKEND)
 
         return parser

--- a/graal/graal.py
+++ b/graal/graal.py
@@ -468,10 +468,10 @@ class GraalCommand(GitCommand):
         setattr(self.parsed_args, 'git_path', git_path)
 
     @staticmethod
-    def setup_cmd_parser(categories, exec_path=False):
+    def setup_cmd_parser(backend, exec_path=False):
         """Returns the Graal argument parser."""
 
-        parser = GraalCommandArgumentParser(categories=categories, from_date=True, to_date=True, exec_path=exec_path)
+        parser = GraalCommandArgumentParser(backend=backend, from_date=True, to_date=True, exec_path=exec_path)
 
         # Optional arguments
         group = parser.parser.add_argument_group('Git arguments')
@@ -514,13 +514,13 @@ class GraalCommandArgumentParser:
     of the executable can be set during the initialization
     of the instance.
 
-    :param categories: set category argument
+    :param backend: set backend argument
     :param from_date: set from_date argument
     :param to_date: set to_date argument
     :param exec_path: set the path of the analysis tool executable
     """
-    def __init__(self, categories, from_date=False, to_date=False, exec_path=False):
-        self._categories = categories
+    def __init__(self, backend, from_date=False, to_date=False, exec_path=False):
+        self._backend = backend
         self._from_date = from_date
         self._to_date = to_date
         self._exec_path = exec_path
@@ -529,7 +529,7 @@ class GraalCommandArgumentParser:
 
         group = self.parser.add_argument_group('general arguments')
         group.add_argument('--category', dest='category',
-                           help="type of the items to fetch (%s)" % ','.join(self._categories))
+                           help="type of the items to fetch (%s)" % ','.join(self._backend.CATEGORIES))
         group.add_argument('--tag', dest='tag',
                            help="tag the items generated during the fetching process")
 

--- a/tests/test_cocom.py
+++ b/tests/test_cocom.py
@@ -322,7 +322,7 @@ class TestCoComCommand(unittest.TestCase):
 
         parser = CoComCommand.setup_cmd_parser()
         self.assertIsInstance(parser, GraalCommandArgumentParser)
-        self.assertEqual(parser._categories, CoCom.CATEGORIES)
+        self.assertEqual(parser._backend, CoCom)
 
         args = ['http://example.com/',
                 '--git-path', '/tmp/gitpath',

--- a/tests/test_codep.py
+++ b/tests/test_codep.py
@@ -167,7 +167,7 @@ class TestCoDepCommand(unittest.TestCase):
 
         parser = CoDepCommand.setup_cmd_parser()
         self.assertIsInstance(parser, GraalCommandArgumentParser)
-        self.assertEqual(parser._categories, CoDep.CATEGORIES)
+        self.assertEqual(parser._backend, CoDep)
 
         args = ['http://example.com/',
                 '--git-path', '/tmp/gitpath',

--- a/tests/test_colang.py
+++ b/tests/test_colang.py
@@ -243,7 +243,7 @@ class TestCoLangCommand(unittest.TestCase):
 
         parser = CoLangCommand.setup_cmd_parser()
         self.assertIsInstance(parser, GraalCommandArgumentParser)
-        self.assertEqual(parser._categories, CoLang.CATEGORIES)
+        self.assertEqual(parser._backend, CoLang)
 
         args = ['http://example.com/',
                 '--git-path', '/tmp/gitpath',

--- a/tests/test_colic.py
+++ b/tests/test_colic.py
@@ -306,7 +306,7 @@ class TestCoLicCommand(unittest.TestCase):
         parser = CoLicCommand.setup_cmd_parser()
 
         self.assertIsInstance(parser, GraalCommandArgumentParser)
-        self.assertEqual(parser._categories, CoLic.CATEGORIES)
+        self.assertEqual(parser._backend, CoLic)
 
         args = ['http://example.com/',
                 '--git-path', '/tmp/gitpath',

--- a/tests/test_coqua.py
+++ b/tests/test_coqua.py
@@ -253,7 +253,7 @@ class TestCoDepCommand(unittest.TestCase):
         parser = CoQuaCommand.setup_cmd_parser()
 
         self.assertIsInstance(parser, GraalCommandArgumentParser)
-        self.assertEqual(parser._categories, CoQua.CATEGORIES)
+        self.assertEqual(parser._backend, CoQua)
 
         args = ['http://example.com/',
                 '--git-path', '/tmp/gitpath',

--- a/tests/test_covuln.py
+++ b/tests/test_covuln.py
@@ -202,7 +202,7 @@ class TestCoVulnCommand(unittest.TestCase):
         parser = CoVulnCommand.setup_cmd_parser()
 
         self.assertIsInstance(parser, GraalCommandArgumentParser)
-        self.assertEqual(parser._categories, CoVuln.CATEGORIES)
+        self.assertEqual(parser._backend, CoVuln)
 
         args = ['http://example.com/',
                 '--git-path', '/tmp/gitpath',

--- a/tests/test_graal.py
+++ b/tests/test_graal.py
@@ -146,7 +146,7 @@ class MockedGraalCommand(GraalCommand):
     @classmethod
     def setup_cmd_parser(cls):
 
-        parser = GraalCommand.setup_cmd_parser(cls.BACKEND.CATEGORIES)
+        parser = GraalCommand.setup_cmd_parser(cls.BACKEND)
 
         return parser
 
@@ -638,7 +638,7 @@ class TestGraalCommand(unittest.TestCase):
     def test_setup_cmd_parser(self):
         """Test if it parser object is correctly initialized"""
 
-        parser = GraalCommand.setup_cmd_parser(CATEGORY_MOCKED)
+        parser = GraalCommand.setup_cmd_parser(Graal)
         self.assertIsInstance(parser, GraalCommandArgumentParser)
 
         args = ['http://example.com/',
@@ -658,7 +658,7 @@ class TestGraalCommand(unittest.TestCase):
         self.assertEqual(parsed_args.out_paths, None)
         self.assertEqual(parsed_args.entrypoint, None)
         self.assertFalse(parsed_args.details)
-        self.assertEqual(parser._categories, CATEGORY_MOCKED)
+        self.assertEqual(parser._backend, Graal)
 
         args = ['http://example.com/',
                 '--git-path', '/tmp/gitpath',
@@ -687,7 +687,7 @@ class TestGraalCommand(unittest.TestCase):
         self.assertEqual(parsed_args.entrypoint, 'module')
         self.assertTrue(parsed_args.details)
 
-        parser = GraalCommand.setup_cmd_parser(CATEGORY_MOCKED, exec_path=True)
+        parser = GraalCommand.setup_cmd_parser(Graal, exec_path=True)
         self.assertIsInstance(parser, GraalCommandArgumentParser)
 
         args = ['http://example.com/',
@@ -709,7 +709,7 @@ class TestGraalCommand(unittest.TestCase):
         self.assertEqual(parsed_args.out_paths, None)
         self.assertEqual(parsed_args.entrypoint, None)
         self.assertFalse(parsed_args.details)
-        self.assertEqual(parser._categories, CATEGORY_MOCKED)
+        self.assertEqual(parser._backend, Graal)
 
 
 class TesGraalFunctions(unittest.TestCase):


### PR DESCRIPTION
This code changes the signature of the class `BackendCommandArgumentParser`,
which now accepts as first parameter the backend object instead
its categories. This change is needed to simplify accessing other backend
attributes, beyond the categories.

All backends and corresponding tests have been updated.

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>