### PR TITLE
[graal] Replace git cmd with /usr/bin/git

### DIFF
--- a/graal/graal.py
+++ b/graal/graal.py
@@ -44,6 +44,7 @@ from ._version import __version__
 
 CATEGORY_GRAAL = 'graal'
 DEFAULT_WORKTREE_PATH = '/tmp/worktrees/'
+GIT_EXEC_PATH = '/usr/bin/git'
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +88,7 @@ class Graal(Git):
     :raises RepositoryError: raised when there was an error cloning or
         updating the repository.
     """
-    version = '0.5.0'
+    version = '0.5.1'
 
     CATEGORIES = [CATEGORY_GRAAL]
 
@@ -285,7 +286,7 @@ class GraalRepository(GitRepository):
         if not branch:
             branch = 'master'
 
-        cmd_worktree = ['git', 'worktree', 'add', self.worktreepath, branch]
+        cmd_worktree = [GIT_EXEC_PATH, 'worktree', 'add', self.worktreepath, branch]
 
         try:
             self._exec(cmd_worktree, cwd=self.dirpath, env=self.gitenv)
@@ -307,7 +308,7 @@ class GraalRepository(GitRepository):
         :param worktreepath: directory where the working tree is located
         """
         GraalRepository.delete(self.worktreepath)
-        cmd_worktree = ['git', 'worktree', 'prune']
+        cmd_worktree = [GIT_EXEC_PATH, 'worktree', 'prune']
         try:
             self._exec(cmd_worktree, cwd=self.dirpath, env=self.gitenv)
             logger.debug("Git worktree %s deleted!" % self.worktreepath)
@@ -320,7 +321,7 @@ class GraalRepository(GitRepository):
 
         :param hash: the hash of a commit
         """
-        cmd_checkout = ['git', 'checkout', '-f', hash]
+        cmd_checkout = [GIT_EXEC_PATH, 'checkout', '-f', hash]
         try:
             self._exec(cmd_checkout, cwd=self.worktreepath, env=self.gitenv)
             logger.debug("Git repository %s checked out!" % self.dirpath)
@@ -335,7 +336,7 @@ class GraalRepository(GitRepository):
 
         :returns: a BytesIO object
         """
-        cmd_archive = ['git', 'archive', '--format=tar', hash]
+        cmd_archive = [GIT_EXEC_PATH, 'archive', '--format=tar', hash]
 
         try:
             outs = self._exec(cmd_archive, cwd=self.dirpath, env=self.gitenv)

--- a/tests/test_graal.py
+++ b/tests/test_graal.py
@@ -36,6 +36,7 @@ from perceval.utils import DEFAULT_DATETIME, DEFAULT_LAST_DATETIME
 import graal
 from graal.graal import (DEFAULT_WORKTREE_PATH,
                          CATEGORY_GRAAL,
+                         GIT_EXEC_PATH,
                          Graal,
                          GraalCommand,
                          GraalRepository,
@@ -59,7 +60,7 @@ class MockedGraalRepository(GraalRepository):
               encoding='utf-8'):
 
         if MockedGraalRepository.RAISE_EXCEPTION:
-            if cmd[:2] == ["git", "archive"]:
+            if cmd[:2] == [GIT_EXEC_PATH, "archive"]:
                 raise OSError
 
             raise Exception
@@ -591,7 +592,7 @@ class TestGraalRepository(TestCaseGraal):
 
     @staticmethod
     def __git_show_hash(repo):
-        cmd_show = ['git', 'show']
+        cmd_show = [GIT_EXEC_PATH, 'show']
         try:
             outs = repo._exec(cmd_show, cwd=repo.worktreepath, env=repo.gitenv)
         except Exception:


### PR DESCRIPTION
This code replaces the git command with its full path. This change is needed since for some repositories such as `git` and `mysql-server`, the git checkout command wasn't found.