### PR TITLE
Fix lizard package dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ the analysis to filter in/out files and directories in the repository (**in_path
 and define the **details** level of the analysis (useful when analyzing large software projects).
 
 ## Requirements
-- [lizard](https://github.com/terryyin/lizard)>=1.16.3
+- [lizard](https://github.com/terryyin/lizard)==1.16.6
 - [perceval](https://github.com/chaoss/grimoirelab-perceval)>=0.9.6
 - [pylint](https://github.com/PyCQA/pylint)>=1.8.4
 - [flake8](https://github.com/PyCQA/flake8)>=3.7.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lizard>=1.16.3
+lizard==1.16.6
 pylint>=1.8.4
 flake8>=3.7.7
 networkx>=2.1

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(name="graal",
       ],
       namespace_packages=['graal', 'graal.backends'],
       install_requires=[
-          'lizard>=1.16.3',
+          'lizard==1.16.6',
           'perceval>=0.12.0',
           'pylint>=1.8.4',
           'flake8>=3.7.7',


### PR DESCRIPTION
Due to an error in the latest version of lizard (1.17.x), graal fails during the instalation. This commit fixes that error pinning the lizard version to 1.16.6.
