### PR TITLE
[travis] Upgrade setuptools and pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ python:
 sudo: false
 
 before_install:
+  - pip install --upgrade setuptools
+  - pip install --upgrade pip
   - pip install -r "requirements.txt"
   - pip install flake8
   - pip install coveralls


### PR DESCRIPTION
This code upgrades the setuptools and pip. This change is needed to fix the CI tests that were failing due to the following error:
```
Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/setuptools/sandbox.py", line 154, in save_modules
        yield saved
      File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/setuptools/sandbox.py", line 195, in setup_context
        yield
      File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/setuptools/sandbox.py", line 250, in run_setup
        _execfile(setup_script, ns)
      File "/home/travis/virtualenv/python3.5.6/lib/python3.5/site-packages/setuptools/sandbox.py", line 44, in _execfile
        code = compile(script, filename, 'exec')
      File "/tmp/easy_install-wu9lgsxc/pandoc-2.0a4/setup.py", line 11
        error = f"pip is not installed, refer to <{url}> for instructions."
                                                                          ^
    SyntaxError: invalid syntax
```

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>