### PR TITLE
[cocom] Include parents info in docs generated

### DIFF
--- a/graal/backends/core/cocom.py
+++ b/graal/backends/core/cocom.py
@@ -84,7 +84,7 @@ class CoCom(Graal):
     :raises RepositoryError: raised when there was an error cloning or
         updating the repository.
     """
-    version = '0.4.0'
+    version = '0.5.0'
 
     CATEGORIES = [CATEGORY_COCOM_LIZARD_FILE,
                   CATEGORY_COCOM_LIZARD_REPOSITORY,
@@ -223,7 +223,6 @@ class CoCom(Graal):
         :param commit: a Graal commit item
         """
         commit.pop('files', None)
-        commit.pop('parents', None)
         commit.pop('refs', None)
         commit['analyzer'] = self.analyzer_kind
 

--- a/tests/test_cocom.py
+++ b/tests/test_cocom.py
@@ -88,7 +88,7 @@ class TestCoComBackend(TestCaseRepo):
             self.assertTrue('Author' in commit['data'])
             self.assertTrue('Commit' in commit['data'])
             self.assertFalse('files' in commit['data'])
-            self.assertFalse('parents' in commit['data'])
+            self.assertTrue('parents' in commit['data'])
             self.assertFalse('refs' in commit['data'])
 
     def test_fetch_scc_file(self):
@@ -108,7 +108,7 @@ class TestCoComBackend(TestCaseRepo):
             self.assertTrue('Author' in commit['data'])
             self.assertTrue('Commit' in commit['data'])
             self.assertFalse('files' in commit['data'])
-            self.assertFalse('parents' in commit['data'])
+            self.assertTrue('parents' in commit['data'])
             self.assertFalse('refs' in commit['data'])
 
     def test_fetch_lizard_repository(self):
@@ -126,7 +126,7 @@ class TestCoComBackend(TestCaseRepo):
             self.assertTrue('Author' in commit['data'])
             self.assertTrue('Commit' in commit['data'])
             self.assertFalse('files' in commit['data'])
-            self.assertFalse('parents' in commit['data'])
+            self.assertTrue('parents' in commit['data'])
             self.assertFalse('refs' in commit['data'])
 
     def test_fetch_scc_repository(self):
@@ -144,7 +144,7 @@ class TestCoComBackend(TestCaseRepo):
             self.assertTrue('Author' in commit['data'])
             self.assertTrue('Commit' in commit['data'])
             self.assertFalse('files' in commit['data'])
-            self.assertFalse('parents' in commit['data'])
+            self.assertTrue('parents' in commit['data'])
             self.assertFalse('refs' in commit['data'])
 
     def test_fetch_unknown(self):


### PR DESCRIPTION
This code includes the `parents` info to the documents returned by the cocom backend. This change is needed to allow navigate the commit graph on the cocom data.

Tests have been updated accordingly.
Backend version is now 0.5.0