### PR TITLE
[cocom] Include files info in docs generated

### DIFF
--- a/graal/backends/core/cocom.py
+++ b/graal/backends/core/cocom.py
@@ -215,6 +215,7 @@ class CoCom(Graal):
         else:
             files_affected = [file_info['file'] for file_info in commit['files']]
             analysis = self.analyzer.analyze(self.worktreepath, files_affected)
+
         return analysis
 
     def _post(self, commit):
@@ -222,7 +223,7 @@ class CoCom(Graal):
 
         :param commit: a Graal commit item
         """
-        commit.pop('files', None)
+        commit['files'] = [f.replace(self.worktreepath, '') for f in GraalRepository.files(self.worktreepath)]
         commit.pop('refs', None)
         commit['analyzer'] = self.analyzer_kind
 

--- a/tests/test_cocom.py
+++ b/tests/test_cocom.py
@@ -87,7 +87,7 @@ class TestCoComBackend(TestCaseRepo):
                              'perceval/backends/core/github.py')
             self.assertTrue('Author' in commit['data'])
             self.assertTrue('Commit' in commit['data'])
-            self.assertFalse('files' in commit['data'])
+            self.assertTrue('files' in commit['data'])
             self.assertTrue('parents' in commit['data'])
             self.assertFalse('refs' in commit['data'])
 
@@ -107,7 +107,7 @@ class TestCoComBackend(TestCaseRepo):
                              'perceval/backends/core/github.py')
             self.assertTrue('Author' in commit['data'])
             self.assertTrue('Commit' in commit['data'])
-            self.assertFalse('files' in commit['data'])
+            self.assertTrue('files' in commit['data'])
             self.assertTrue('parents' in commit['data'])
             self.assertFalse('refs' in commit['data'])
 
@@ -125,7 +125,7 @@ class TestCoComBackend(TestCaseRepo):
             self.assertEqual(commit['category'], CATEGORY_COCOM_LIZARD_REPOSITORY)
             self.assertTrue('Author' in commit['data'])
             self.assertTrue('Commit' in commit['data'])
-            self.assertFalse('files' in commit['data'])
+            self.assertTrue('files' in commit['data'])
             self.assertTrue('parents' in commit['data'])
             self.assertFalse('refs' in commit['data'])
 
@@ -143,7 +143,7 @@ class TestCoComBackend(TestCaseRepo):
             self.assertEqual(commit['category'], CATEGORY_COCOM_SCC_REPOSITORY)
             self.assertTrue('Author' in commit['data'])
             self.assertTrue('Commit' in commit['data'])
-            self.assertFalse('files' in commit['data'])
+            self.assertTrue('files' in commit['data'])
             self.assertTrue('parents' in commit['data'])
             self.assertFalse('refs' in commit['data'])
 


### PR DESCRIPTION
This code includes the `files` info to the documents returned by the cocom backend. This change is needed to have a global view over all files in a git revision

Tests have been updated accordingly.
Backend version is now 0.6.0