### PR TITLE
[travis] Change how to install nomos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+dist: bionic
+os: linux
 
 python:
   - "3.5"
@@ -12,11 +14,15 @@ before_install:
   - pip install -r "requirements.txt"
   - pip install flake8
   - pip install coveralls
-  - sudo apt-get install cloc
   - gem install github-linguist
   - pip install bandit
   - pip install pylint
   - pip install execnet
+  - wget https://github.com/fossology/fossology/releases/download/3.8.1/FOSSology-3.8.0-debian9stretch.tar.gz
+  - tar -xzf FOSSology-3.8.0-debian9stretch.tar.gz
+  - sudo apt-get update -y
+  - sudo apt-get -y install ./packages/fossology-common_3.8.1-1_amd64.deb ./packages/fossology-nomos_3.8.1-1_amd64.deb
+  - sudo apt-get install cloc
 
 install:
   - ./setup.py install
@@ -25,10 +31,6 @@ before_script:
   - mkdir exec
   - cd exec
   - go get -u github.com/boyter/scc/
-  - git clone https://github.com/fossology/fossology
-  - cd fossology/src/nomos/agent/
-  - sudo apt-get install libjson-c-dev
-  - make -f Makefile.sa FO_LDFLAGS="-lglib-2.0 -lpq -lglib-2.0 -ljson-c -lpthread -lrt"
   - cd /home/travis/build/chaoss/grimoirelab-graal/exec
   - git clone https://github.com/nexB/scancode-toolkit.git
   - cd scancode-toolkit

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,7 +21,7 @@
 #     Valerio Cosentino <valcos@bitergia.com>
 #
 
-NOMOS_PATH = "/home/travis/build/chaoss/grimoirelab-graal/exec/fossology/src/nomos/agent/nomossa"
+NOMOS_PATH = "/usr/share/fossology/nomos/agent/nomossa"
 SCANCODE_PATH = "/home/travis/build/chaoss/grimoirelab-graal/exec/scancode-toolkit/scancode"
 SCANCODE_CLI_PATH = "/home/travis/build/chaoss/grimoirelab-graal/exec/scancode-toolkit/etc/scripts/scancli.py"
 JADOLINT_PATH = "/home/travis/build/chaoss/grimoirelab-graal/exec/jadolint.jar"


### PR DESCRIPTION
This code changes the way how to install the nomos. Thus, instead of creating the executable, it relies on the deb packages fossology-common and fossology-nomos.
    
Due to the missing dependency libjson-c3 in the defaul distribution used by Travis (`xenial`), the distribution has been set to `bionic`.
    
The nomossa executable path has been updated accordingly.