### PR TITLE
[ci] Install dev packages using Poetry instead of peodd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,11 @@ jobs:
         with:
           go-version: '^1.17'
 
+      - name: Install poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
+
       - name: Install dependencies
         run: |
           gem install github-linguist -v 7.15
@@ -59,9 +64,7 @@ jobs:
 
       - name: Install dev dependencies
         run: |
-          pip install peodd
-          peodd -o requirements-dev.txt
-          pip install -r requirements-dev.txt
+          poetry install --only dev --no-root
 
       - name: Install requirements
         run: |
@@ -80,8 +83,8 @@ jobs:
       - name: Test package
         run: |
           PACKAGE=`(cd dist && ls *whl)` && echo $PACKAGE
-          pip install --pre ./dist/$PACKAGE
-          cd tests && python run_tests.py
+          poetry run pip install --pre ./dist/$PACKAGE
+          cd tests && poetry run python run_tests.py
 
   release:
     needs: [tests]


### PR DESCRIPTION
Poetry supports installing packages from a specific group since version `1.2`. Replace the use of `peodd` with Poetry in the installation of the test packages