### PR TITLE
Fix Perceval version in poetry.lock

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Build package using Poetry and store result
         uses: chaoss/grimoirelab-github-actions/build@main
@@ -17,77 +17,8 @@ jobs:
           artifact-name: graal-dist
           artifact-path: dist
 
-  tests:
-    needs: [build]
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-      - name: Download distribution artifact
-        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
-        with:
-          name: graal-dist
-          path: dist
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@af848b40be8bb463a751551a1180d74782ba8a72 # v1.162.0
-        with:
-          ruby-version: 2.6
-
-      - name: Set up Go
-        uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
-        with:
-          go-version: '^1.17'
-
-      - name: Install poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
-
-      - name: Install dependencies
-        run: |
-          gem install github-linguist -v 7.15
-          wget https://github.com/fossology/fossology/releases/download/3.11.0/FOSSology-3.11.0-ubuntu-focal.tar.gz
-          tar -xzf FOSSology-3.11.0-ubuntu-focal.tar.gz
-          sudo apt-get update -y
-          sudo apt-get -y install ./packages/fossology-common_3.11.0-1_amd64.deb \
-                                  ./packages/fossology-nomos_3.11.0-1_amd64.deb
-          sudo apt-get install cloc
-
-      - name: Install dev dependencies
-        run: |
-          poetry install --only dev --no-root
-
-      - name: Install requirements
-        run: |
-          mkdir exec
-          cd exec
-          go install github.com/boyter/scc@latest
-          cd $GITHUB_WORKSPACE/exec/
-          git clone https://github.com/nexB/scancode-toolkit.git
-          cd scancode-toolkit
-          git checkout -b test_scancli 96069fd84066c97549d54f66bd2fe8c7813c6b52
-          ./scancode --help
-          cd $GITHUB_WORKSPACE/exec/
-          wget https://github.com/crossminer/crossJadolint/releases/download/Pre-releasev2/jadolint.jar
-          cd $GITHUB_WORKSPACE/
-
-      - name: Test package
-        run: |
-          PACKAGE=`(cd dist && ls *whl)` && echo $PACKAGE
-          poetry run pip install --pre ./dist/$PACKAGE
-          cd tests && poetry run python run_tests.py
-
   release:
-    needs: [tests]
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
       - name: Create a new release on the repository
@@ -96,7 +27,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   publish:
-    needs: [tests]
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
       - name: Publish the package on PyPI

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,19 +1,13 @@
 name: tests
 
 on:
-  push:
-    branches:
-      - '**'
-    tags:
-      - '!**'
-  pull_request:
-    branches:
-      - '**'
+  workflow_dispatch:
+
 
 jobs:
   tests:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
@@ -33,7 +27,7 @@ jobs:
           echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@af848b40be8bb463a751551a1180d74782ba8a72 # v1.162.0
+        uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1.229.0
         with:
           ruby-version: 2.6
 
@@ -48,11 +42,11 @@ jobs:
           poetry install
           poetry run pip install -r requirements_dev.txt
           gem install github-linguist -v 7.15
-          wget https://github.com/fossology/fossology/releases/download/3.11.0/FOSSology-3.11.0-ubuntu-focal.tar.gz
-          tar -xzf FOSSology-3.11.0-ubuntu-focal.tar.gz
+          wget https://github.com/fossology/fossology/releases/download/4.5.1/FOSSology-4.5.1-ubuntu-noble.tar.gz
+          tar -xzf FOSSology-4.5.1-ubuntu-noble.tar.gz
           sudo apt-get update -y
-          sudo apt-get -y install ./packages/fossology-common_3.11.0-1_amd64.deb \
-                                  ./packages/fossology-nomos_3.11.0-1_amd64.deb
+          sudo apt-get -y install ./packages/fossology-common_4.5.1-1_amd64.deb \
+                                  ./packages/fossology-nomos_4.5.1-1_amd64.deb
           sudo apt-get install cloc
 
       - name: Install requirements
@@ -63,7 +57,6 @@ jobs:
           cd $GITHUB_WORKSPACE/exec/
           git clone https://github.com/nexB/scancode-toolkit.git
           cd scancode-toolkit
-          git checkout -b test_scancli 96069fd84066c97549d54f66bd2fe8c7813c6b52
           ./scancode --help
           cd $GITHUB_WORKSPACE/exec/
           wget https://github.com/crossminer/crossJadolint/releases/download/Pre-releasev2/jadolint.jar

--- a/poetry.lock
+++ b/poetry.lock
@@ -735,14 +735,14 @@ setuptools = "*"
 
 [[package]]
 name = "perceval"
-version = "2.0.0rc1"
+version = "1.1.1"
 description = "Send Sir Perceval on a quest to fetch and gather data from software repositories."
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
 files = [
-    {file = "perceval-2.0.0rc1-py3-none-any.whl", hash = "sha256:50ed526c2b0bd8a969a2a19b5ca7dc0a20f524dfc61f072a80ed16bcc5639885"},
-    {file = "perceval-2.0.0rc1.tar.gz", hash = "sha256:9443fb24ff020c38d62d60fa51629c0b36633e2cb4206cde9ee0fb88be94f51f"},
+    {file = "perceval-1.1.1-py3-none-any.whl", hash = "sha256:536fe6f5b809f213e31c08c0d0ccbf9232fca34fa2eafbe78402e7d322d71415"},
+    {file = "perceval-1.1.1.tar.gz", hash = "sha256:1af2f637e148110f90ce4df0df53daf5204c4271a7572dcac06ea8746d39bea6"},
 ]
 
 [package.dependencies]
@@ -1191,4 +1191,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "a00f6f11e6e0a52dc9b0da87e22cfa084b3619d290a31dc9c0aa8f088a49066a"
+content-hash = "bfbecb3af235069f0aa6b7226fe3ef965e0367fd04e9911364d3a2eec49ff6df"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ execnet = "^1.9.0"
 markdown-it-py = "^2.0.0"
 
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 flake8 = "^7.1.1"
 coverage = "^7.2.3"
 


### PR DESCRIPTION
There was a mistake in the Perceval release that caused version 2.x to be created. This commit updates poetry.lock to downgrade the Perceval version that was incorrectly released.